### PR TITLE
Add real-time Deepgram meeting transcription dashboard

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,12 @@ func main() {
 
 	r := gin.Default()
 	r.Use(cors.Default())
-	r.Static("/", "./static")
+
+	r.Static("/static", "./static")
+	r.GET("/", func(c *gin.Context) {
+		c.File("./static/index.html")
+	})
+	r.StaticFile("/favicon.ico", "./static/favicon.ico")
 	r.GET("/ws", liveTranscribe(dg))
 
 	log.Printf("starting server on :%s", port)

--- a/main.go
+++ b/main.go
@@ -2,115 +2,150 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
-	"io"
-	"mime"
+	"log"
 	"net/http"
 	"os"
-	"path/filepath"
-	"strings"
+	"sync"
+	"time"
 
 	"github.com/deepgram-devs/deepgram-go-sdk/deepgram"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
 	"github.com/joho/godotenv"
 )
 
-type TranscriptionResponse struct {
-	Model            string                                   `json:"model,omitempty"`
-	Version          string                                   `json:"version,omitempty"`
-	Tier             string                                   `json:"tier,omitempty"`
-	DeepgramFeatures deepgram.PreRecordedTranscriptionOptions `json:"dgFeatures,omitempty"`
-	Transcription    deepgram.PreRecordedResponse             `json:"transcription,omitempty"`
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024 * 8,
+	WriteBufferSize: 1024 * 8,
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
+
+type wsWriter struct {
+	mu   sync.Mutex
+	conn *websocket.Conn
+}
+
+func (w *wsWriter) write(messageType int, payload []byte) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.conn.WriteMessage(messageType, payload)
 }
 
 func main() {
-	godotenv.Load()
-	dg := deepgram.NewClient(os.Getenv("deepgram_api_key"))
+	if err := godotenv.Load(); err != nil {
+		log.Println("no .env file found, relying on environment variables")
+	}
+
+	apiKey := os.Getenv("deepgram_api_key")
+	if apiKey == "" {
+		log.Fatal("deepgram_api_key is required")
+	}
+
+	port := os.Getenv("port")
+	if port == "" {
+		port = "8080"
+	}
+
+	dg := deepgram.NewClient(apiKey)
 
 	r := gin.Default()
 	r.Use(cors.Default())
 	r.Static("/", "./static")
+	r.GET("/ws", liveTranscribe(dg))
 
-	r.POST("/api", transcribe(dg))
-
-	r.Run("localhost:" + os.Getenv("port"))
+	log.Printf("starting server on :%s", port)
+	if err := r.Run(":" + port); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
 }
 
-func transcribe(dg *deepgram.Client) gin.HandlerFunc {
-
-	fn := func(c *gin.Context) {
-		url := c.PostForm("url")
-		model := c.PostForm("model")
-		version := c.PostForm("version")
-		tier := c.PostForm("tier")
-		features := c.PostForm("features")
-
-		var dgFeatures deepgram.PreRecordedTranscriptionOptions
-		err := json.Unmarshal([]byte(features), &dgFeatures)
+func liveTranscribe(dg *deepgram.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
 		if err != nil {
-			c.AbortWithError(http.StatusInternalServerError, err)
+			log.Printf("websocket upgrade failed: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		options := deepgram.LiveTranscriptionOptions{
+			Model:           "nova-2",
+			Language:        "en-US",
+			Punctuate:       true,
+			Smart_format:    true,
+			Interim_results: true,
+			Encoding:        "opus",
+			Channels:        1,
+			Sample_rate:     48000,
 		}
 
-		dgFeatures.Model = model
-		if len(version) > 0 {
-			dgFeatures.Version = version
+		dgConn, _, err := dg.LiveTranscription(options)
+		if err != nil {
+			log.Printf("unable to connect to deepgram: %v", err)
+			_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"error":"Unable to connect to Deepgram"}`))
+			return
 		}
+		defer dgConn.Close()
 
-		if model != "whisper" {
-			dgFeatures.Tier = tier
-		}
+		writer := &wsWriter{conn: conn}
+		done := make(chan struct{})
 
-		if strings.HasPrefix(url, "https://res.cloudinary.com/deepgram") {
-			transcription, err := dg.PreRecordedFromURL(deepgram.UrlSource{Url: url}, dgFeatures)
+		go func() {
+			defer close(done)
+			for {
+				messageType, message, err := dgConn.ReadMessage()
+				if err != nil {
+					log.Printf("error reading from deepgram: %v", err)
+					return
+				}
+				if len(message) == 0 {
+					continue
+				}
+				if err := writer.write(messageType, message); err != nil {
+					log.Printf("error writing to websocket client: %v", err)
+					return
+				}
+			}
+		}()
+
+		for {
+			messageType, message, err := conn.ReadMessage()
 			if err != nil {
-				panic(err)
+				log.Printf("client connection closed: %v", err)
+				break
 			}
 
-			res := TranscriptionResponse{
-				Model:            model,
-				Version:          version,
-				Tier:             tier,
-				DeepgramFeatures: dgFeatures,
-				Transcription:    transcription,
-			}
-
-			c.JSON(http.StatusOK, res)
-		} else {
-			file, err := c.FormFile("file")
-			if err != nil {
-				c.AbortWithError(http.StatusBadRequest, errors.New("you need to choose a file to transcribe your own audio"))
+			switch messageType {
+			case websocket.CloseMessage:
 				return
+			case websocket.TextMessage:
+				var payload map[string]string
+				if err := json.Unmarshal(message, &payload); err != nil {
+					continue
+				}
+				if payload["event"] == "stop" {
+					break
+				}
+			case websocket.BinaryMessage:
+				if len(message) == 0 {
+					continue
+				}
+				if err := dgConn.WriteMessage(websocket.BinaryMessage, message); err != nil {
+					log.Printf("error forwarding audio to deepgram: %v", err)
+					return
+				}
 			}
+		}
 
-			uploadedFile, err := file.Open()
-			if err != nil {
-				c.AbortWithError(http.StatusBadRequest, errors.New("cannot open file"))
-			}
-			defer uploadedFile.Close()
+		_ = dgConn.WriteMessage(websocket.TextMessage, []byte(`{"type":"CloseStream"}`))
+		_ = dgConn.Close()
 
-			stream := uploadedFile.(io.ReadCloser)
-			mime := mime.TypeByExtension(filepath.Ext(file.Filename))
-
-			transcription, err := dg.PreRecordedFromStream(
-				deepgram.ReadStreamSource{Stream: stream, Mimetype: mime},
-				dgFeatures)
-			if err != nil {
-				c.AbortWithError(http.StatusInternalServerError, err)
-			}
-
-			res := TranscriptionResponse{
-				Model:            model,
-				Version:          version,
-				Tier:             tier,
-				DeepgramFeatures: dgFeatures,
-				Transcription:    *transcription,
-			}
-
-			c.JSON(http.StatusOK, res)
-
+		select {
+		case <-done:
+		case <-time.After(500 * time.Millisecond):
 		}
 	}
-
-	return gin.HandlerFunc(fn)
 }

--- a/static/app.js
+++ b/static/app.js
@@ -1,15 +1,570 @@
-import { html, LitElement } from "//cdn.skypack.dev/lit@v2.8.0";
+import { LitElement, html, css } from "//cdn.skypack.dev/lit@v2.8.0";
 
-import "./components/app-header.js";
-import "./components/app-body.js";
+const KEYWORD_WEIGHTS = [
+  ["update", 2],
+  ["progress", 2],
+  ["decision", 3],
+  ["plan", 2],
+  ["design", 1.5],
+  ["deadline", 3],
+  ["issue", 2],
+  ["launch", 1.5],
+  ["review", 1.5],
+  ["deliverable", 2],
+  ["roadmap", 2],
+  ["timeline", 2],
+  ["risk", 2],
+  ["milestone", 2.5],
+  ["next", 1.5],
+  ["goal", 1.5],
+];
 
-class App extends LitElement {
+const ACTION_ITEM_PATTERN =
+  /(need to|should|let's|we'll|plan to|remember to|follow up|assign|schedule|review|finalize|prepare|send|share|set up|update|call|reach out)/i;
+
+class MeetingTranscriber extends LitElement {
+  static properties = {
+    meetingTitle: { type: String },
+    selectedSource: { type: String },
+    isRecording: { type: Boolean },
+    statusMessage: { type: String },
+    transcript: { type: Array },
+    liveSegment: { type: String },
+    keyPoints: { type: Array },
+    actionItems: { type: Array },
+    elapsedMs: { type: Number },
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+      min-height: 100vh;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.meetingTitle = "Weekly sync";
+    this.selectedSource = "microphone";
+    this.isRecording = false;
+    this.statusMessage = "Ready to transcribe";
+    this.transcript = [];
+    this.liveSegment = "";
+    this.keyPoints = [];
+    this.actionItems = [];
+    this.elapsedMs = 0;
+    this.fullTranscript = "";
+    this.socket = null;
+    this.mediaRecorder = null;
+    this.stream = null;
+    this.timer = null;
+    this.wsUrl = this.computeWebsocketUrl();
+
+    this._handleChunk = (event) => {
+      if (
+        !event.data ||
+        event.data.size === 0 ||
+        !this.socket ||
+        this.socket.readyState !== WebSocket.OPEN
+      ) {
+        return;
+      }
+
+      event.data.arrayBuffer().then((buffer) => {
+        if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+          this.socket.send(buffer);
+        }
+      });
+    };
+
+    this._handleRecorderStop = () => {
+      if (this.mediaRecorder) {
+        this.mediaRecorder.removeEventListener("dataavailable", this._handleChunk);
+        this.mediaRecorder.removeEventListener("stop", this._handleRecorderStop);
+        this.mediaRecorder = null;
+      }
+      this.cleanupStream();
+    };
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.wsUrl = this.computeWebsocketUrl();
+  }
+
+  disconnectedCallback() {
+    this.stopSession();
+    super.disconnectedCallback();
+  }
+
+  computeWebsocketUrl() {
+    const { protocol, host } = window.location;
+    const scheme = protocol === "https:" ? "wss" : "ws";
+    return `${scheme}://${host}/ws`;
+  }
+
+  updateMeetingTitle(event) {
+    this.meetingTitle = event.target.value;
+  }
+
+  setSource(source) {
+    if (this.isRecording) return;
+    this.selectedSource = source;
+  }
+
+  async startSession() {
+    if (this.isRecording) return;
+
+    try {
+      this.statusMessage = "Preparing audio";
+      this.requestUpdate();
+
+      const stream = await this.acquireStream();
+      this.stream = stream;
+
+      const mimeType = this.chooseMimeType();
+      try {
+        this.mediaRecorder = mimeType
+          ? new MediaRecorder(stream, { mimeType })
+          : new MediaRecorder(stream);
+      } catch (error) {
+        throw new Error(
+          "MediaRecorder is not supported in this browser. Try Chrome or Edge."
+        );
+      }
+
+      this.mediaRecorder.addEventListener("dataavailable", this._handleChunk);
+      this.mediaRecorder.addEventListener("stop", this._handleRecorderStop);
+
+      this.socket = new WebSocket(this.wsUrl);
+      this.socket.binaryType = "arraybuffer";
+
+      this.socket.addEventListener("open", () => {
+        this.elapsedMs = 0;
+        this.startTimer();
+        this.mediaRecorder.start(750);
+        this.isRecording = true;
+        this.statusMessage =
+          this.selectedSource === "system"
+            ? "Capturing system audio"
+            : "Capturing microphone";
+        this.requestUpdate();
+      });
+
+      this.socket.addEventListener("message", (event) => {
+        this.handleTranscriptEvent(event);
+      });
+
+      this.socket.addEventListener("error", () => {
+        if (this.isRecording) {
+          this.stopSession();
+          this.statusMessage = "Connection issue detected";
+        } else {
+          this.cleanupSocket();
+          this.cleanupStream();
+          this.statusMessage = "Websocket error";
+        }
+        this.requestUpdate();
+      });
+
+      this.socket.addEventListener("close", () => {
+        const wasRecording = this.isRecording;
+        this.isRecording = false;
+        this.stopTimer();
+        if (wasRecording) {
+          this.statusMessage =
+            this.statusMessage === "Recording stopped"
+              ? this.statusMessage
+              : "Connection closed";
+          this.requestUpdate();
+        }
+      });
+    } catch (error) {
+      console.error(error);
+      this.statusMessage = error.message || "Unable to start recording";
+      this.cleanupStream();
+      this.cleanupSocket();
+      this.requestUpdate();
+    }
+  }
+
+  stopSession() {
+    this.cleanupSocket(true);
+
+    if (this.mediaRecorder && this.mediaRecorder.state !== "inactive") {
+      try {
+        this.mediaRecorder.stop();
+      } catch (error) {
+        console.error("Failed to stop media recorder", error);
+        this._handleRecorderStop();
+      }
+    } else {
+      this._handleRecorderStop();
+    }
+
+    this.stopTimer();
+    this.isRecording = false;
+    this.statusMessage = "Recording stopped";
+    this.requestUpdate();
+  }
+
+  async acquireStream() {
+    if (!navigator.mediaDevices) {
+      throw new Error("Media devices are not available in this browser.");
+    }
+    if (this.selectedSource === "system") {
+      const stream = await navigator.mediaDevices.getDisplayMedia({
+        audio: true,
+        video: true,
+      });
+      const hasAudio = stream.getAudioTracks().length > 0;
+      if (!hasAudio) {
+        stream.getTracks().forEach((track) => track.stop());
+        throw new Error(
+          "No audio was shared. Please share a tab or window that has audio enabled."
+        );
+      }
+      return stream;
+    }
+
+    return navigator.mediaDevices.getUserMedia({
+      audio: {
+        sampleRate: 48000,
+        channelCount: 1,
+        echoCancellation: true,
+        noiseSuppression: true,
+      },
+      video: false,
+    });
+  }
+
+  chooseMimeType() {
+    if (!window.MediaRecorder) return "";
+    const types = [
+      "audio/webm;codecs=opus",
+      "audio/webm",
+      "audio/ogg;codecs=opus",
+    ];
+    return types.find((type) => MediaRecorder.isTypeSupported(type)) || "";
+  }
+
+  cleanupSocket(sendStop = false) {
+    if (!this.socket) return;
+
+    const socket = this.socket;
+    this.socket = null;
+
+    try {
+      if (sendStop && socket.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({ event: "stop" }));
+      }
+    } catch (error) {
+      console.warn("Failed to send stop event", error);
+    }
+
+    try {
+      socket.close();
+    } catch (error) {
+      console.warn("Failed to close websocket", error);
+    }
+  }
+
+  cleanupStream() {
+    if (this.stream) {
+      this.stream.getTracks().forEach((track) => track.stop());
+      this.stream = null;
+    }
+  }
+
+  startTimer() {
+    this.stopTimer();
+    this.timer = setInterval(() => {
+      this.elapsedMs += 1000;
+      this.requestUpdate();
+    }, 1000);
+  }
+
+  stopTimer() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  handleTranscriptEvent(event) {
+    try {
+      const payload = JSON.parse(event.data);
+      if (payload.error) {
+        this.statusMessage = payload.error;
+        this.requestUpdate();
+        return;
+      }
+
+      const alternative = payload?.channel?.alternatives?.[0];
+      const transcript = alternative?.transcript?.trim();
+      if (!transcript) return;
+
+      if (payload.is_final) {
+        this.transcript = [
+          ...this.transcript,
+          {
+            text: transcript,
+            start: payload.start ?? Date.now() / 1000,
+          },
+        ];
+        this.fullTranscript = `${this.fullTranscript} ${transcript}`.trim();
+        this.liveSegment = "";
+        this.updateInsights();
+      } else {
+        this.liveSegment = transcript;
+      }
+      this.requestUpdate();
+    } catch (error) {
+      console.error("Failed to parse transcript message", error);
+    }
+  }
+
+  updateInsights() {
+    const sentences = this.fullTranscript
+      .split(/(?<=[.!?])\s+/)
+      .map((sentence) => sentence.trim())
+      .filter((sentence) => sentence.length > 0);
+
+    if (!sentences.length) {
+      this.keyPoints = [];
+      this.actionItems = [];
+      return;
+    }
+
+    const scored = sentences.map((sentence, index) => ({
+      sentence,
+      index,
+      score: this.scoreSentence(sentence),
+    }));
+
+    const unique = new Set();
+    const keyPoints = [];
+
+    for (const entry of scored
+      .sort((a, b) => b.score - a.score || a.index - b.index)) {
+      const normalized = entry.sentence.replace(/\s+/g, " ").trim();
+      if (!normalized || unique.has(normalized.toLowerCase())) continue;
+      if (normalized.length < 35 && entry.score < 2 && keyPoints.length > 0) {
+        continue;
+      }
+      unique.add(normalized.toLowerCase());
+      keyPoints.push(normalized);
+      if (keyPoints.length >= 5) break;
+    }
+
+    if (!keyPoints.length && sentences.length) {
+      keyPoints.push(sentences[0]);
+    }
+
+    const actionItems = sentences.filter((sentence) =>
+      ACTION_ITEM_PATTERN.test(sentence)
+    );
+
+    this.keyPoints = keyPoints;
+    this.actionItems = Array.from(
+      new Set(actionItems.map((item) => item.replace(/\s+/g, " ").trim()))
+    ).slice(0, 5);
+  }
+
+  scoreSentence(sentence) {
+    const lowered = sentence.toLowerCase();
+    let score = 0;
+    for (const [keyword, weight] of KEYWORD_WEIGHTS) {
+      if (lowered.includes(keyword)) {
+        score += weight;
+      }
+    }
+    if (sentence.length > 120) score += 1.5;
+    if (/\b(we|team|stakeholder|client|release)\b/i.test(sentence)) {
+      score += 1;
+    }
+    return score;
+  }
+
+  resetBoard() {
+    this.stopSession();
+    this.transcript = [];
+    this.liveSegment = "";
+    this.keyPoints = [];
+    this.actionItems = [];
+    this.fullTranscript = "";
+    this.statusMessage = "Ready to transcribe";
+    this.requestUpdate();
+  }
+
+  renderInsightList(items, placeholder) {
+    if (items.length === 0) {
+      return html`<p class="insight-placeholder">${placeholder}</p>`;
+    }
+
+    return html`<ul>
+      ${items.map(
+        (item) => html`<li>
+          <span class="bullet"></span>
+          <span>${item}</span>
+        </li>`
+      )}
+    </ul>`;
+  }
+
+  get notesText() {
+    if (!this.transcript.length) {
+      return "Add context during the conversation and we'll capture the highlights for you.";
+    }
+    const latest = this.transcript[this.transcript.length - 1]?.text ?? "";
+    if (!latest) {
+      return "Keep the conversation going to capture more insights.";
+    }
+    return latest.length > 220 ? `${latest.slice(0, 217)}…` : latest;
+  }
+
+  formatDuration(milliseconds) {
+    const totalSeconds = Math.floor(milliseconds / 1000);
+    const minutes = Math.floor(totalSeconds / 60)
+      .toString()
+      .padStart(2, "0");
+    const seconds = (totalSeconds % 60).toString().padStart(2, "0");
+    return `${minutes}:${seconds}`;
+  }
+
   render() {
     return html`
-      <app-header></app-header>
-      <app-body></app-body>
+      <div class="app-shell">
+        <header class="top-bar">
+          <div class="brand">
+            <div class="brand-mark">Transcribe</div>
+            <span class="brand-tag">Powered by Deepgram</span>
+          </div>
+          <nav class="top-nav">
+            <a href="#" class="active">Home</a>
+            <a href="#">My Files</a>
+            <a href="#">New File</a>
+          </nav>
+          <button class="new-session" @click=${this.resetBoard}>
+            New Session
+          </button>
+        </header>
+        <main class="main-content">
+          <section class="panel transcription">
+            <div class="panel-header">
+              <div>
+                <h1>Meeting Transcription</h1>
+                <p>
+                  Follow conversations in real time, capture decisions, and surface
+                  the moments that matter most to your team.
+                </p>
+              </div>
+              <div class=${`live-status ${this.isRecording ? "recording" : ""}`}>
+                <span class="status-dot"></span>
+                <span>${this.isRecording ? "Live" : "Idle"}</span>
+                <span class="duration">${this.formatDuration(this.elapsedMs)}</span>
+              </div>
+            </div>
+            <div class="meeting-meta">
+              <label>
+                <span>Meeting title</span>
+                <input
+                  type="text"
+                  placeholder="e.g. Quarterly product review"
+                  .value=${this.meetingTitle}
+                  @input=${this.updateMeetingTitle}
+                />
+              </label>
+              <div class="status-message">${this.statusMessage}</div>
+            </div>
+            <div class="controls">
+              <div class="control-group">
+                <span class="label">Audio source</span>
+                <div class="source-options">
+                  <button
+                    class=${`source-button ${
+                      this.selectedSource === "microphone" ? "active" : ""
+                    }`}
+                    @click=${() => this.setSource("microphone")}
+                  >
+                    Microphone
+                  </button>
+                  <button
+                    class=${`source-button ${
+                      this.selectedSource === "system" ? "active" : ""
+                    }`}
+                    @click=${() => this.setSource("system")}
+                  >
+                    System audio
+                  </button>
+                </div>
+              </div>
+              <div class="control-group action-buttons">
+                ${this.isRecording
+                  ? html`<button class="stop" @click=${this.stopSession}>
+                      Stop recording
+                    </button>`
+                  : html`<button class="start" @click=${this.startSession}>
+                      Start recording
+                    </button>`}
+              </div>
+            </div>
+            <div class="transcript-window">
+              ${this.transcript.length === 0 && !this.liveSegment
+                ? html`<div class="empty-state">
+                    <h3>Ready when you are</h3>
+                    <p>
+                      Select an audio source and press start to begin transcribing
+                      your meeting in real time.
+                    </p>
+                  </div>`
+                : html`
+                    ${this.transcript.map(
+                      (segment, index) => html`<div class="utterance">
+                        <span class="utterance-index">${index + 1}</span>
+                        <p>${segment.text}</p>
+                      </div>`
+                    )}
+                    ${this.liveSegment
+                      ? html`<div class="utterance live">
+                          <span class="utterance-index">•</span>
+                          <p>${this.liveSegment}</p>
+                        </div>`
+                      : null}
+                  `}
+            </div>
+          </section>
+          <aside class="panel summary">
+            <h2>Summary</h2>
+            <div class="insight-section">
+              <div class="section-heading">
+                <h3>Key Points</h3>
+                <span>${this.keyPoints.length}/5</span>
+              </div>
+              ${this.renderInsightList(
+                this.keyPoints,
+                "Key insights will appear here as the conversation progresses."
+              )}
+            </div>
+            <div class="insight-section">
+              <div class="section-heading">
+                <h3>Action Items</h3>
+                <span>${this.actionItems.length}/5</span>
+              </div>
+              ${this.renderInsightList(
+                this.actionItems,
+                "Call out follow-ups or next steps to capture action items automatically."
+              )}
+            </div>
+            <div class="notes-section">
+              <h3>Notes</h3>
+              <p>${this.notesText}</p>
+            </div>
+          </aside>
+        </main>
+      </div>
     `;
   }
 }
 
-customElements.define("deepgram-starter-ui", App);
+customElements.define("meeting-transcriber", MeetingTranscriber);

--- a/static/index.html
+++ b/static/index.html
@@ -10,9 +10,9 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="preflight.css" />
-    <link rel="stylesheet" href="style.css" />
-    <script type="module" src="./app.js"></script>
+    <link rel="stylesheet" href="/static/preflight.css" />
+    <link rel="stylesheet" href="/static/style.css" />
+    <script type="module" src="/static/app.js"></script>
   </head>
   <body>
     <meeting-transcriber></meeting-transcriber>

--- a/static/index.html
+++ b/static/index.html
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script type="module" src="./app.js"></script>
-    <script type="module" src="./components/app-spinner.js"></script>
-    <link rel="stylesheet" href="preflight.css" />
+    <title>Meeting Transcriber</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css?family=Fira+Code"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="stylesheet" href="preflight.css" />
     <link rel="stylesheet" href="style.css" />
+    <script type="module" src="./app.js"></script>
   </head>
-
   <body>
-    <deepgram-starter-ui></deepgram-starter-ui>
-    <!-- <app-spinner></app-spinner> -->
+    <meeting-transcriber></meeting-transcriber>
   </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -1,11 +1,522 @@
-html {
-  color: white;
-  background: linear-gradient(3.95deg, #101014 3.44%, rgba(0, 0, 0, 0) 174.43%),
-    linear-gradient(270deg, #27336a 24.96%, #0c0310 50.78%, #370c4d 76.47%);
+:root {
+  color-scheme: dark;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #070b12;
+  color: #f4f6fb;
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(120% 120% at 15% 10%, #1c2434 0%, rgba(28, 36, 52, 0) 65%),
+    radial-gradient(100% 100% at 85% 0%, #142035 0%, rgba(20, 32, 53, 0) 60%),
+    #060910;
+  color: inherit;
+}
+
+meeting-transcriber {
+  display: block;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding-bottom: 3rem;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.75rem 2.5rem;
+  background: rgba(13, 18, 27, 0.8);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.brand-mark {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.06rem;
+}
+
+.brand-tag {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgba(244, 246, 251, 0.6);
+  text-transform: uppercase;
+  letter-spacing: 0.2rem;
+}
+
+.top-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.top-nav a {
+  color: rgba(244, 246, 251, 0.65);
+  font-weight: 500;
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.top-nav a.active,
+.top-nav a:hover {
+  color: #ffffff;
+}
+
+.new-session {
+  padding: 0.65rem 1.5rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, #2d68ff 0%, #4db2ff 100%);
+  color: #fff;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.new-session:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(77, 178, 255, 0.28);
+}
+
+.main-content {
+  flex: 1;
+  display: flex;
+  gap: 2rem;
+  width: min(1200px, 92vw);
+  margin: 0 auto;
+}
+
+.panel {
+  background: rgba(17, 23, 33, 0.9);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  box-shadow: 0 30px 60px rgba(5, 8, 14, 0.55);
+}
+
+.transcription {
+  flex: 3;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.summary {
+  flex: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: rgba(13, 18, 28, 0.85);
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.panel-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.panel-header p {
+  margin: 0.75rem 0 0;
+  color: rgba(244, 246, 251, 0.7);
+  line-height: 1.6;
+  max-width: 40rem;
+}
+
+.live-status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(244, 246, 251, 0.8);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08rem;
+  font-size: 0.8rem;
+}
+
+.live-status.recording {
+  background: rgba(255, 80, 80, 0.16);
+  color: #ffb6b6;
+}
+
+.status-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: rgba(244, 246, 251, 0.6);
+  box-shadow: 0 0 0 0 rgba(255, 76, 76, 0.6);
+  animation: pulse 2.4s infinite;
+}
+
+.live-status.recording .status-dot {
+  background: #ff5252;
+}
+
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(255, 76, 76, 0.4);
+  }
+  70% {
+    box-shadow: 0 0 0 12px rgba(255, 76, 76, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 76, 76, 0);
+  }
+}
+
+.duration {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: rgba(244, 246, 251, 0.9);
+}
+
+.meeting-meta {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.meeting-meta label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  flex: 1;
+  font-size: 0.9rem;
+  color: rgba(244, 246, 251, 0.7);
+}
+
+.meeting-meta input {
+  padding: 0.85rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(10, 14, 22, 0.65);
+  color: #f4f6fb;
+  font-size: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.meeting-meta input:focus {
+  outline: none;
+  border-color: rgba(77, 178, 255, 0.65);
+  box-shadow: 0 0 0 4px rgba(77, 178, 255, 0.15);
+}
+
+.status-message {
+  min-width: 200px;
+  text-align: right;
+  font-weight: 600;
+  color: rgba(244, 246, 251, 0.65);
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.control-group .label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgba(244, 246, 251, 0.7);
+}
+
+.source-options {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.source-button {
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(10, 14, 22, 0.6);
+  color: rgba(244, 246, 251, 0.85);
+  font-weight: 600;
+  cursor: pointer;
+  transition: border 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.source-button:hover {
+  border-color: rgba(77, 178, 255, 0.5);
+  box-shadow: 0 10px 20px rgba(11, 16, 24, 0.45);
+}
+
+.source-button.active {
+  background: linear-gradient(140deg, rgba(77, 178, 255, 0.2), rgba(59, 132, 255, 0.28));
+  border-color: rgba(77, 178, 255, 0.85);
+  color: #ffffff;
+  box-shadow: 0 14px 35px rgba(77, 178, 255, 0.3);
+}
+
+.action-buttons button {
+  padding: 0.85rem 2.8rem;
+  border-radius: 1rem;
+  border: none;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.action-buttons .start {
+  background: linear-gradient(135deg, #3effb1 0%, #37d2ff 100%);
+  color: #061019;
+  box-shadow: 0 18px 40px rgba(55, 210, 255, 0.35);
+}
+
+.action-buttons .start:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 48px rgba(55, 210, 255, 0.45);
+}
+
+.action-buttons .stop {
+  background: rgba(255, 82, 82, 0.12);
+  color: #ff9f9f;
+  border: 1px solid rgba(255, 105, 105, 0.5);
+  box-shadow: 0 18px 36px rgba(255, 82, 82, 0.25);
+}
+
+.action-buttons .stop:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 44px rgba(255, 82, 82, 0.35);
+}
+
+.transcript-window {
+  background: rgba(8, 12, 20, 0.75);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  height: 28rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.transcript-window::-webkit-scrollbar {
+  width: 0.6rem;
+}
+
+.transcript-window::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 1rem;
+}
+
+.empty-state {
+  text-align: center;
+  margin: auto;
+  max-width: 28rem;
+  color: rgba(244, 246, 251, 0.7);
+}
+
+.empty-state h3 {
+  font-size: 1.3rem;
+  margin-bottom: 0.75rem;
+  color: #f4f6fb;
+}
+
+.utterance {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1rem 1.1rem;
+  border-radius: 1rem;
+  background: rgba(18, 24, 34, 0.75);
+  border: 1px solid transparent;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.utterance:hover {
+  border-color: rgba(77, 178, 255, 0.3);
+  transform: translateY(-1px);
+}
+
+.utterance.live {
+  border-color: rgba(77, 178, 255, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(77, 178, 255, 0.3);
+}
+
+.utterance-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: rgba(244, 246, 251, 0.8);
+}
+
+.utterance p {
+  margin: 0;
+  color: rgba(244, 246, 251, 0.9);
+  line-height: 1.6;
+}
+
+.summary h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.insight-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08rem;
+  color: rgba(244, 246, 251, 0.6);
+}
+
+.section-heading span {
+  font-size: 0.85rem;
+  color: rgba(244, 246, 251, 0.45);
+}
+
+.insight-section ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.insight-section li {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  line-height: 1.5;
+  color: rgba(244, 246, 251, 0.85);
+}
+
+.insight-section .bullet {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  margin-top: 0.45rem;
+  background: linear-gradient(135deg, #4db2ff 0%, #3effb1 100%);
+  flex-shrink: 0;
+}
+
+.insight-placeholder {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(244, 246, 251, 0.6);
+  line-height: 1.6;
+}
+
+.notes-section {
+  padding: 1.2rem;
+  border-radius: 1.1rem;
+  background: rgba(9, 13, 21, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  color: rgba(244, 246, 251, 0.8);
+  line-height: 1.6;
+}
+
+.notes-section h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: rgba(244, 246, 251, 0.9);
+}
+
+.notes-section p {
+  margin: 0;
+}
+
+button {
+  font-family: inherit;
+}
+
+@media (max-width: 1080px) {
+  .main-content {
+    flex-direction: column;
+  }
+
+  .summary {
+    order: -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .top-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .top-nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .main-content {
+    width: 90vw;
+  }
+
+  .meeting-meta {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .status-message {
+    text-align: left;
+  }
+
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .source-options {
+    flex-wrap: wrap;
+  }
+
+  .action-buttons button {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the prerecorded transcription endpoint with a websocket handler that streams audio to Deepgram and relays live transcripts
- build a meeting-focused front-end that captures microphone or system audio, streams it in real time, and derives key points and action items from the transcript
- refresh the layout and styling to match the provided inspiration, including summary and live status panels

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cf25b6d27883239e4ba0e847db3c73